### PR TITLE
Use SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylamarzocco"
 version = "1.4.3"
-license = { text = "MIT License" }
+license = { text = "MIT" }
 description = "A Python implementation of the new La Marzocco API"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Use the SPDX license identifier for `MIT`. This will become the default suggestion once build backends fully implement PEP 639. However, it's possible to use them with the legacy `license.text` field already.

https://spdx.org/licenses/MIT.html
https://peps.python.org/pep-0639/