### PR TITLE
V2.0.0-alpha.1 Linea Mini fixes

### DIFF
--- a/pylamarzocco/const.py
+++ b/pylamarzocco/const.py
@@ -157,6 +157,7 @@ class BoilerStatus(StrEnum):
     STAND_BY = "StandBy"
     HEATING = "HeatingUp"
     READY = "Ready"
+    NO_WATER = "NoWater"
     OFF = "Off"
 
 

--- a/pylamarzocco/models/_config.py
+++ b/pylamarzocco/models/_config.py
@@ -452,3 +452,11 @@ class ThingScale(BaseWidgetOutput):
     calibration_required: bool = field(
         metadata=field_options(alias="calibrationRequired")
     )
+
+
+@dataclass(kw_only=True)
+class NoWater(BaseWidgetOutput):
+    """No water status."""
+
+    widget_type = WidgetType.CM_NO_WATER
+    allarm: bool = field(metadata=field_options(alias="allarm"))

--- a/pylamarzocco/models/_config.py
+++ b/pylamarzocco/models/_config.py
@@ -459,4 +459,4 @@ class NoWater(BaseWidgetOutput):
     """No water status."""
 
     widget_type = WidgetType.CM_NO_WATER
-    allarm: bool = field(metadata=field_options(alias="allarm"))
+    allarm: bool


### PR DESCRIPTION
Running `example.py` on my Linea Mini resulted in two errors on my first attempt. Note that, the last time I had turned off my LM prior to running the example script, the water tank was empty.

```
Traceback (most recent call last):
  File "<string>", line 9, in __mashumaro_from_dict__
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/enum.py", line 751, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/enum.py", line 1165, in __new__
    raise ve_exc
ValueError: 'NoWater' is not a valid BoilerStatus

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 22, in __mashumaro_from_dict__
  File "<string>", line 8, in __unpack_Widget_output__885b3cf2b6ba4a3da65cfb2c26b6495e
  File "<string>", line 11, in __mashumaro_from_dict__
mashumaro.exceptions.InvalidFieldValue: Field "status" of type BoilerStatus in CoffeeBoiler has invalid value 'NoWater'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 105, in __mashumaro_from_dict__
  File "<string>", line 24, in __mashumaro_from_dict__
mashumaro.exceptions.InvalidFieldValue: Field "output" of type BaseWidgetOutput in Widget has invalid value {'status': 'NoWater', 'enabled': True, 'enabledSupported': False, 'targetTemperature': 90.0, 'targetTemperatureMin': 80, 'targetTemperatureMax': 100, 'targetTemperatureStep': 0.1, 'readyStartTime': None, 'widget_type': 'CMCoffeeBoiler'}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/tim/Developer/pylamarzocco/example.py", line 41, in <module>
    asyncio.run(main())
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/tim/Developer/pylamarzocco/example.py", line 18, in main
    await machine.get_dashboard()
  File "/Users/tim/Developer/pylamarzocco/pylamarzocco/devices/_thing.py", line 37, in wrapper
    return await func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tim/Developer/pylamarzocco/pylamarzocco/devices/_thing.py", line 107, in get_dashboard
    self.dashboard = await self._cloud_client.get_thing_dashboard(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tim/Developer/pylamarzocco/pylamarzocco/clients/_cloud.py", line 190, in get_thing_dashboard
    return ThingDashboardConfig.from_dict(result)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 107, in __mashumaro_from_dict__
mashumaro.exceptions.InvalidFieldValue: Field "widgets" of type list[Widget] in ThingDashboardConfig has invalid value [{'code': 'CMMachineStatus', 'index': 1, 'output': {'status': 'StandBy', 'availableModes': ['BrewingMode', 'StandBy'], 'mode': 'StandBy', 'nextStatus': None, 'brewingStartTime': None, 'widget_type': 'CMMachineStatus'}, 'tutorialUrl': None}, {'code': 'CMCoffeeBoiler', 'index': 1, 'output': {'status': 'NoWater', 'enabled': True, 'enabledSupported': False, 'targetTemperature': 90.0, 'targetTemperatureMin': 80, 'targetTemperatureMax': 100, 'targetTemperatureStep': 0.1, 'readyStartTime': None, 'widget_type': 'CMCoffeeBoiler'}, 'tutorialUrl': None}, {'code': 'CMSteamBoilerTemperature', 'index': 1, 'output': {'status': 'NoWater', 'enabled': True, 'enabledSupported': True, 'targetTemperature': 0.0, 'targetTemperatureSupported': False, 'targetTemperatureMin': 95, 'targetTemperatureMax': 140, 'targetTemperatureStep': 0.1, 'readyStartTime': None, 'widget_type': 'CMSteamBoilerTemperature'}, 'tutorialUrl': None}, {'code': 'CMPreBrewing', 'index': 1, 'output': {'availableModes': ['PreBrewing', 'Disabled'], 'mode': 'Disabled', 'times': {'PreBrewing': [{'doseIndex': 'ByGroup', 'seconds': {'In': 5.0, 'Out': 5.0}, 'secondsMin': {'In': 1, 'Out': 1}, 'secondsMax': {'In': 9, 'Out': 9}, 'secondsStep': {'In': 0.1, 'Out': 0.1}}]}, 'doseIndexSupported': False, 'widget_type': 'CMPreBrewing'}, 'tutorialUrl': 'https://www.lamarzocco.com/it/en/app/support/brewing-features/#gs3-av-linea-micra-linea-mini-home'}, {'code': 'CMBackFlush', 'index': 1, 'output': {'lastCleaningStartTime': None, 'status': 'Off', 'widget_type': 'CMBackFlush'}, 'tutorialUrl': 'http://lamarzocco.com/it/en/app/support/cleaning-and-backflush/#linea-mini'}, {'code': 'CMNoWater', 'index': 1, 'output': {'allarm': True, 'widget_type': 'CMNoWater'}, 'tutorialUrl': None}]
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x101e3ca40>
Unclosed connector
connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x101e4ef90>, 206369.992465958)])']
connector: <aiohttp.connector.TCPConnector object at 0x101e3d9a0>
```