### PR TITLE
Fix command name for pre-extraction times update

### DIFF
--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -552,7 +552,7 @@ class LaMarzoccoCloudClient:
         """Change pre-extraction times"""
 
         return await self.__execute_command(
-            serial_number, "CoffeeMachinePreBrewingChangeTimes", times.to_dict()
+            serial_number, "CoffeeMachinePreBrewingSettingTimes", times.to_dict()
         )
 
     async def set_smart_standby(


### PR DESCRIPTION
Corrects the command from 'CoffeeMachinePreBrewingChangeTimes' to 'CoffeeMachinePreBrewingSettingTimes' as per #85.

Huge thank you to @neuralldev for creating #85.