### PR TITLE
Fix command name for wake-up schedule update

### DIFF
--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -671,7 +671,7 @@ class LaMarzoccoCloudClient:
     ) -> bool:
         """Set smart wakeup schedule"""
         return await self.__execute_command(
-            serial_number, "CoffeeMachineSetWakeUpSchedule", schedule.to_dict()
+            serial_number, "CoffeeMachineSettingWakeUpSchedule", schedule.to_dict()
         )
 
     async def change_brew_by_weight_dose_mode(

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -544,7 +544,7 @@ async def test_set_wake_up_schedule(
 ) -> None:
     """Test setting the wake up schedule for a thing."""
 
-    url = f"{CUSTOMER_APP_URL}/things/{serial}/command/CoffeeMachineSetWakeUpSchedule"
+    url = f"{CUSTOMER_APP_URL}/things/{serial}/command/CoffeeMachineSettingWakeUpSchedule"
     mock_aioresponse.post(
         url=url,
         status=200,


### PR DESCRIPTION
Corrects the command from `CoffeeMachineSetWakeUpSchedule` to `CoffeeMachineSettingWakeUpSchedule` — the same `Set`/`Change` → `Setting` rename from #85 that #105 already applied to the pre-extraction times command.

The current cloud rejects the old name with `400 — "Parameter 'commandType' must be 'CustomerAppThingCommandType'"` (that error is the cloud's response to an unknown command name, not a payload complaint).

Verified live on a Linea Mini R (Gateway v7.1.6 / Machine v1.20, 2026-06-12): the old name 400s; with the new name the schedule appears on a subsequent read of `/things/{serial}/scheduling`. `CoffeeMachineDeleteWakeUpSchedule` survived the rename and still works as-is.

One observation that may be worth documenting (happy to file separately): schedule application is async — the command returns `{"status":"Pending"}` and the schedule lands a few seconds later, so confirmation requires re-reading the scheduling endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)