### PR TITLE
Add grinder wake/standby (GrinderChangeMode) + follow-ups from #149 review

### DIFF
--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -692,10 +692,7 @@ class LaMarzoccoCloudClient:
         enabled: bool,
         index: int = 1,
     ) -> bool:
-        """Enable or disable the barista light of a grinder.
-
-        Note: the grinder ignores setting commands while in StandBy.
-        """
+"""Enable or disable the barista light of a grinder."""
         data = {"index": index, "enabled": enabled}
         return await self.__execute_command(
             serial_number, "GrinderSettingBaristaLightEnabled", data

--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -680,12 +680,7 @@ class LaMarzoccoCloudClient:
         serial_number: str,
         mode: GrinderMode,
     ) -> bool:
-        """Set the grinder mode (GrindingMode wakes it, StandBy puts it to sleep).
-
-        The grinder ignores setting commands while in StandBy, so waking it
-        first is required before any other grinder command. Application is
-        asynchronous: the dashboard reflects the change a few seconds later.
-        """
+        """Set the grinder mode (GrindingMode wakes it, StandBy puts it to sleep). """
         data = {"mode": mode.value}
         return await self.__execute_command(
             serial_number, "GrinderChangeMode", data

--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -28,6 +28,7 @@ from pylamarzocco.const import (
     CUSTOMER_APP_URL,
     CommandStatus,
     DoseMode,
+    GrinderMode,
     PreExtractionMode,
     SmartStandByType,
     SteamTargetLevel,
@@ -674,16 +675,33 @@ class LaMarzoccoCloudClient:
             serial_number, "CoffeeMachineSettingWakeUpSchedule", schedule.to_dict()
         )
 
+    async def set_grinder_mode(
+        self,
+        serial_number: str,
+        mode: GrinderMode,
+    ) -> bool:
+        """Set the grinder mode (GrindingMode wakes it, StandBy puts it to sleep).
+
+        The grinder ignores setting commands while in StandBy, so waking it
+        first is required before any other grinder command. Application is
+        asynchronous: the dashboard reflects the change a few seconds later.
+        """
+        data = {"mode": mode.value}
+        return await self.__execute_command(
+            serial_number, "GrinderChangeMode", data
+        )
+
     async def set_grinder_barista_light(
         self,
         serial_number: str,
         enabled: bool,
+        index: int = 1,
     ) -> bool:
         """Enable or disable the barista light of a grinder.
 
         Note: the grinder ignores setting commands while in StandBy.
         """
-        data = {"index": 1, "enabled": enabled}
+        data = {"index": index, "enabled": enabled}
         return await self.__execute_command(
             serial_number, "GrinderSettingBaristaLightEnabled", data
         )

--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -692,7 +692,7 @@ class LaMarzoccoCloudClient:
         enabled: bool,
         index: int = 1,
     ) -> bool:
-    """Enable or disable the barista light of a grinder."""
+        """Enable or disable the barista light of a grinder."""
         data = {"index": index, "enabled": enabled}
         return await self.__execute_command(
             serial_number, "GrinderSettingBaristaLightEnabled", data

--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -692,7 +692,7 @@ class LaMarzoccoCloudClient:
         enabled: bool,
         index: int = 1,
     ) -> bool:
-"""Enable or disable the barista light of a grinder."""
+    """Enable or disable the barista light of a grinder."""
         data = {"index": index, "enabled": enabled}
         return await self.__execute_command(
             serial_number, "GrinderSettingBaristaLightEnabled", data

--- a/pylamarzocco/devices/_grinder.py
+++ b/pylamarzocco/devices/_grinder.py
@@ -4,14 +4,36 @@ from __future__ import annotations
 
 from typing import cast
 
-from pylamarzocco.const import WidgetType
-from pylamarzocco.models import GrinderBaristaLight
+from pylamarzocco.const import GrinderMode, WidgetType
+from pylamarzocco.models import GrinderBaristaLight, GrinderMachineStatus
 
 from ._thing import LaMarzoccoThing, cloud_only
 
 
 class LaMarzoccoGrinder(LaMarzoccoThing):
     """Class for La Marzocco grinder."""
+
+    @cloud_only
+    async def set_power(self, enabled: bool) -> bool:
+        """Wake the grinder (GrindingMode) or send it to StandBy.
+
+        The grinder ignores all other setting commands while in StandBy, so
+        wake it first. The cloud applies the change asynchronously (the
+        dashboard catches up a few seconds later).
+        """
+        assert self._cloud_client
+        mode = GrinderMode.GRINDING if enabled else GrinderMode.STANDBY
+        result = await self._cloud_client.set_grinder_mode(self.serial_number, mode)
+
+        # Update dashboard if command succeeded
+        if result and WidgetType.G_MACHINE_STATUS in self.dashboard.config:
+            machine_status = cast(
+                GrinderMachineStatus,
+                self.dashboard.config[WidgetType.G_MACHINE_STATUS],
+            )
+            machine_status.mode = mode
+
+        return result
 
     @cloud_only
     async def set_barista_light(self, enabled: bool) -> bool:

--- a/pylamarzocco/devices/_grinder.py
+++ b/pylamarzocco/devices/_grinder.py
@@ -15,12 +15,7 @@ class LaMarzoccoGrinder(LaMarzoccoThing):
 
     @cloud_only
     async def set_power(self, enabled: bool) -> bool:
-        """Wake the grinder (GrindingMode) or send it to StandBy.
-
-        The grinder ignores all other setting commands while in StandBy, so
-        wake it first. The cloud applies the change asynchronously (the
-        dashboard catches up a few seconds later).
-        """
+        """Wake the grinder (GrindingMode) or send it to StandBy."""
         assert self._cloud_client
         mode = GrinderMode.GRINDING if enabled else GrinderMode.STANDBY
         result = await self._cloud_client.set_grinder_mode(self.serial_number, mode)

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -17,6 +17,7 @@ from pylamarzocco.const import (
     CUSTOMER_APP_URL,
     CommandStatus,
     DoseMode,
+    GrinderMode,
     PreExtractionMode,
     SmartStandByType,
     SteamTargetLevel,
@@ -156,11 +157,11 @@ async def test_get_thing_dashboard(
 
 async def test_get_grinder_dashboard(
     mock_aioresponse: aioresponses,
-    serial: str,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test getting the dashboard for a grinder."""
 
+    serial = "GR123456"  # matches the fixture's serialNumber
     mock_aioresponse.get(
         url=f"{CUSTOMER_APP_URL}/things/{serial}/dashboard",
         status=200,
@@ -280,6 +281,30 @@ async def test_set_power_with_ws_validation(
 
     call = mock_aioresponse.requests[(HTTPMethod.POST, URL(url))][0]
     assert call.kwargs["json"] == {"mode": "StandBy"}
+    assert result is True
+
+
+@pytest.mark.usefixtures("mock_websocket", "mock_wait_for_ws_command_response")
+async def test_set_grinder_mode(
+    mock_aioresponse: aioresponses,
+    serial: str,
+) -> None:
+    """Test setting the mode (wake/standby) for a grinder."""
+
+    url = f"{CUSTOMER_APP_URL}/things/{serial}/command/GrinderChangeMode"
+
+    mock_aioresponse.post(
+        url=url,
+        status=200,
+        payload=MOCK_COMMAND_RESPONSE,
+    )
+
+    client = LaMarzoccoCloudClient("test", "test", MOCK_SECRET_DATA)
+
+    result = await client.set_grinder_mode(serial, GrinderMode.GRINDING)
+
+    call = mock_aioresponse.requests[(HTTPMethod.POST, URL(url))][0]
+    assert call.kwargs["json"] == {"mode": "GrindingMode"}
     assert result is True
 
 

--- a/tests/test_grinder.py
+++ b/tests/test_grinder.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from pylamarzocco import LaMarzoccoCloudClient, LaMarzoccoGrinder
-from pylamarzocco.const import WidgetType
-from pylamarzocco.models import GrinderBaristaLight
+from pylamarzocco.const import GrinderMode, WidgetType
+from pylamarzocco.models import GrinderBaristaLight, GrinderMachineStatus
 
 
 @pytest.fixture(name="mock_cloud_client")
@@ -26,6 +26,27 @@ def mock_lm_grinder(
         cloud_client=mock_cloud_client,
     )
     return grinder
+
+
+async def test_set_power_updates_mode(
+    mock_grinder: LaMarzoccoGrinder,
+    mock_cloud_client: MagicMock,
+) -> None:
+    """Test the set_power method (wake / standby)."""
+    mock_grinder.dashboard.config[WidgetType.G_MACHINE_STATUS] = GrinderMachineStatus(
+        status=GrinderMode.STANDBY,
+        available_modes=[GrinderMode.GRINDING, GrinderMode.STANDBY],
+        mode=GrinderMode.STANDBY,
+    )
+
+    assert await mock_grinder.set_power(True)
+    mock_cloud_client.set_grinder_mode.assert_called_once_with(
+        "GR123456", GrinderMode.GRINDING
+    )
+
+    status = mock_grinder.dashboard.config[WidgetType.G_MACHINE_STATUS]
+    assert isinstance(status, GrinderMachineStatus)
+    assert status.mode is GrinderMode.GRINDING
 
 
 async def test_set_barista_light(


### PR DESCRIPTION
Follow-up to #149, completing the grinder write surface with the mode command — hardware-verified today on a Pico (fw v2.01).

## Changes

- **`LaMarzoccoCloudClient.set_grinder_mode(serial, mode)`** → `GrinderChangeMode {"mode": "GrindingMode"|"StandBy"}`. Verified live in **both directions** by the `GMachineStatus` widget flipping (StandBy → PoweredOn on `GrindingMode`, and back on `StandBy`); a 200 alone proves nothing for these commands. Application is async — the dashboard catches up a few seconds later (observed 3–15s).
- **`LaMarzoccoGrinder.set_power(enabled)`** — True wakes (GrindingMode), False sleeps (StandBy), mirroring the machine's `set_power` shape for easy switch-entity use in Home Assistant. This matters because the grinder **ignores every other setting command while in StandBy** (e.g. the barista light 200s but never applies) — waking first is mandatory.
- Review follow-ups from #149: `set_grinder_barista_light` now takes `index: int = 1` instead of hard-coding it, and the grinder dashboard test uses a serial consistent with its fixture.
- Tests: client payload test + device-level test (135 passing).

One quirk worth noting: `GMachineStatus.status` reports `PoweredOn` after waking, even though `availableModes` only lists `GrindingMode`/`StandBy` — the mode you *command* and the status you *read back* use different vocabularies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)