### PR TITLE
Fix pending-command Future leak when websocket is disconnected

### DIFF
--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -493,8 +493,6 @@ class LaMarzoccoCloudClient:
         cr = CommandResponse.from_dict(response[0])
 
         # if the websocket is closed we don't want to wait for confirmation.
-        # Register the pending future only when connected, otherwise it would
-        # never be resolved or removed and would leak in _pending_commands.
         if not self.websocket.connected:
             return True
 

--- a/pylamarzocco/clients/_cloud.py
+++ b/pylamarzocco/clients/_cloud.py
@@ -491,12 +491,15 @@ class LaMarzoccoCloudClient:
             data=data,
         )
         cr = CommandResponse.from_dict(response[0])
-        future: Future[CommandResponse] = Future()
-        self._pending_commands[cr.id] = future
 
-        # if the websocket is closed we don't want to wait for confirmation
+        # if the websocket is closed we don't want to wait for confirmation.
+        # Register the pending future only when connected, otherwise it would
+        # never be resolved or removed and would leak in _pending_commands.
         if not self.websocket.connected:
             return True
+
+        future: Future[CommandResponse] = Future()
+        self._pending_commands[cr.id] = future
 
         try:
             # Wait for the future to be completed or timeout

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -259,6 +259,38 @@ async def test_set_power(
     assert result is True
 
 
+async def test_disconnected_commands_do_not_leak_pending(
+    mock_aioresponse: aioresponses,
+    serial: str,
+) -> None:
+    """Fire-and-forget commands (websocket disconnected) must not accumulate
+    in _pending_commands.
+
+    Regression test: the pending future used to be registered before the
+    websocket-connected check, so every command sent while disconnected left
+    an entry that was never resolved or popped. The cloud returns a *unique*
+    id per command, so the leak grows unboundedly -- a constant id (as in
+    MOCK_COMMAND_RESPONSE) would mask it by overwriting the same dict key.
+    """
+
+    url = f"{CUSTOMER_APP_URL}/things/{serial}/command/CoffeeMachineChangeMode"
+
+    for i in range(5):
+        mock_aioresponse.post(
+            url=url,
+            status=200,
+            payload=[{"id": f"cmd-{i}", "status": "Pending", "error_code": None}],
+        )
+
+    client = LaMarzoccoCloudClient("test", "test", MOCK_SECRET_DATA)
+    assert client.websocket.connected is False
+
+    for _ in range(5):
+        assert await client.set_power(serial, False) is True
+
+    assert client._pending_commands == {}
+
+
 @pytest.mark.usefixtures("mock_websocket", "mock_wait_for_ws_command_response")
 async def test_set_power_with_ws_validation(
     mock_aioresponse: aioresponses,

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -264,14 +264,7 @@ async def test_disconnected_commands_do_not_leak_pending(
     serial: str,
 ) -> None:
     """Fire-and-forget commands (websocket disconnected) must not accumulate
-    in _pending_commands.
-
-    Regression test: the pending future used to be registered before the
-    websocket-connected check, so every command sent while disconnected left
-    an entry that was never resolved or popped. The cloud returns a *unique*
-    id per command, so the leak grows unboundedly -- a constant id (as in
-    MOCK_COMMAND_RESPONSE) would mask it by overwriting the same dict key.
-    """
+    in _pending_commands. """
 
     url = f"{CUSTOMER_APP_URL}/things/{serial}/command/CoffeeMachineChangeMode"
 


### PR DESCRIPTION
## Summary

`__execute_command` registers a pending `Future` in `self._pending_commands` *before* checking whether the websocket is connected. On the fire-and-forget path (websocket disconnected), the method returns early without ever resolving or popping that future, so the entry is retained for the lifetime of the client.

Since the cloud assigns a **unique id per command**, these entries accumulate one-per-command and are never reclaimed — an unbounded leak for any client that issues commands without an active dashboard websocket.

  ## Root cause

```python
cr = CommandResponse.from_dict(response[0])
future: Future[CommandResponse] = Future()
self._pending_commands[cr.id] = future   # registered unconditionally

if not self.websocket.connected:
    return True                           # ...then returns without popping
```
The only .pop() calls are after wait_for(...), which the disconnected path never reaches.

##  Fix

Register the future only after confirming the websocket is connected. The disconnected path returns immediately with nothing to track.

## Testing

Added a regression test (test_disconnected_commands_do_not_leak_pending) that sends several commands with the websocket disconnected, using a unique id per command (a constant id, as in the existing MOCK_COMMAND_RESPONSE, would mask the leak by overwriting the same dict key), and asserts _pending_commands drains to {}.

- The test fails against the unpatched code (assert {'cmd-0': <Future pending>, ...} == {}) and passes with the fix.
- Full suite: 134 passed.


**This PR was generated with assistance from Claude Code.**